### PR TITLE
bug: app will save translated string into uci.

### DIFF
--- a/htdocs/luci-static/resources/view/alpha-config.js
+++ b/htdocs/luci-static/resources/view/alpha-config.js
@@ -87,8 +87,8 @@ return view.extend({
 		o = s.option(form.Flag, 'enable', _('Navigation bar'), _('Enable navigation bar.'));
 		o.rmempty = false;
 		o.modalonly = true;
-		o.enabled = _('Enable');
-		o.disabled = _('Disable');
+		o.enabled = 'Enable';
+		o.disabled = 'Disable';
 		o.default = o.enabled;
 		o = s.option(form.Value, 'line', _('Line number'), _('Enter a line number between 1 to 10.'));
 		o.rmempty = false;
@@ -98,8 +98,8 @@ return view.extend({
 		o = s.option(form.Flag, 'newtab', _('Open in new tab'), _('Enable open links in a new tab.'));
 		o.rmempty = false;
 		o.modalonly = true;
-		o.enabled = _('Yes');
-		o.disabled = _('No');
+		o.enabled = 'Yes';
+		o.disabled = 'No';
 		o = s.option(form.FileUpload, 'icon', _('Icon'), _('Upload PNG file with size 256x256.'));
 		o.rmempty = false;
 		o.modalonly = true;


### PR DESCRIPTION
I have luci-i18n-*-ja installed and set as system language.
<img width="73" alt="截屏2025-06-24 12 41 58" src="https://github.com/user-attachments/assets/58fd22b5-b82a-400e-b2b5-3d86d8c5d432" />
Icons which i changed settings disappered,and two languages appeared in the navigation bar configuration section
<img width="362" alt="截屏2025-06-24 12 36 37" src="https://github.com/user-attachments/assets/dd9bb6e0-9004-4d37-80a4-afcfd16e3d53" />
I checked uci entry and found that app just sent translated string into uci entry,which isn't recognizable by navigation bar program.
<img width="255" alt="截屏2025-06-24 12 37 20" src="https://github.com/user-attachments/assets/7a014ace-36ae-4d18-8276-1a30af93927b" />
This commit removed "translatable mark" _() of 'Yes' 'No' 'Enable' and 'Disable' in order to send untranslated string into uci entry.
<img width="342" alt="截屏2025-06-24 12 41 47" src="https://github.com/user-attachments/assets/86507f4f-74df-4565-8460-e5cd417d826b" />
<img width="74" alt="截屏2025-06-24 12 55 31" src="https://github.com/user-attachments/assets/dd4b0fa4-469b-44d9-be09-50784cd30ac7" />
tested locally and it works